### PR TITLE
Quick windows and bazel support ideas

### DIFF
--- a/src/bazel.rs
+++ b/src/bazel.rs
@@ -1,0 +1,318 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+use tracing::{debug, warn};
+use walkdir::WalkDir;
+
+type WorkspaceParseResult = (
+    Option<String>,      // workspace_name
+    Vec<String>,         // rules
+    Vec<String>,         // dependencies
+    Option<PathBuf>,     // workspace_root
+);
+
+#[derive(Debug, Error)]
+pub enum BazelError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Not a Bazel project: no WORKSPACE or WORKSPACE.bazel found")]
+    NotBazelProject,
+
+    #[error("WORKSPACE file is corrupted or unreadable: {0}")]
+    CorruptedWorkspace(String),
+
+    #[error("Multiple issues detected: {0:?}")]
+    MultipleIssues(Vec<String>),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BuildOutput {
+    pub path: PathBuf,
+    pub relative_path: String,
+    pub config: Option<String>,
+    pub cpu: Option<String>,
+    pub compilation_mode: Option<String>,
+    pub has_compile_commands: bool,
+    pub symlink_target: Option<PathBuf>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BazelProjectStatus {
+    pub is_bazel_project: bool,
+    pub workspace_root: PathBuf,
+    pub workspace_name: Option<String>,
+    pub build_outputs: Vec<BuildOutput>,
+    pub rules: Vec<String>,
+    pub dependencies: Vec<String>,
+    pub issues: Vec<String>,
+}
+
+impl BazelProjectStatus {
+    pub fn analyze_current_directory() -> Result<Self, BazelError> {
+        Self::analyze_directory(&std::env::current_dir()?)
+    }
+
+    pub fn analyze_directory(project_path: &Path) -> Result<Self, BazelError> {
+        debug!("Analyzing directory: {:?}", project_path);
+
+        let mut status = BazelProjectStatus {
+            is_bazel_project: false,
+            workspace_root: project_path.to_path_buf(),
+            workspace_name: None,
+            build_outputs: Vec::new(),
+            rules: Vec::new(),
+            dependencies: Vec::new(),
+            issues: Vec::new(),
+        };
+
+        // Check if this is a Bazel project
+        let workspace_file = if project_path.join("WORKSPACE").exists() {
+            project_path.join("WORKSPACE")
+        } else if project_path.join("WORKSPACE.bazel").exists() {
+            project_path.join("WORKSPACE.bazel")
+        } else {
+            return Err(BazelError::NotBazelProject);
+        };
+
+        status.is_bazel_project = true;
+        debug!("Found WORKSPACE file, this is a Bazel project");
+
+        // Parse WORKSPACE file
+        match Self::parse_workspace_file(&workspace_file) {
+            Ok((workspace_name, rules, dependencies, _)) => {
+                status.workspace_name = workspace_name;
+                status.rules = rules;
+                status.dependencies = dependencies;
+            }
+            Err(e) => {
+                let issue = format!("Failed to parse WORKSPACE file: {e}");
+                warn!("{}", issue);
+                status.issues.push(issue);
+            }
+        }
+
+        // Scan for build outputs
+        status.build_outputs = Self::scan_build_outputs(project_path, &mut status.issues)?;
+
+        if !status.issues.is_empty() && status.build_outputs.is_empty() {
+            return Err(BazelError::MultipleIssues(status.issues.clone()));
+        }
+
+        Ok(status)
+    }
+
+    fn scan_build_outputs(
+        workspace_root: &Path,
+        issues: &mut Vec<String>,
+    ) -> Result<Vec<BuildOutput>, BazelError> {
+        let mut build_outputs = Vec::new();
+
+        // Look for bazel-out directory and its subdirectories
+        let bazel_out = workspace_root.join("bazel-out");
+        if bazel_out.exists() {
+            debug!("Found bazel-out directory: {:?}", bazel_out);
+            
+            // Scan for configuration directories (e.g., k8-fastbuild, host, etc.)
+            if let Ok(entries) = fs::read_dir(&bazel_out) {
+                for entry in entries.filter_map(|e| e.ok()) {
+                    if entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+                        let config_path = entry.path();
+                        let config_name = config_path.file_name()
+                            .and_then(|n| n.to_str())
+                            .unwrap_or("unknown")
+                            .to_string();
+
+                        match Self::analyze_build_output(workspace_root, &config_path, &config_name) {
+                            Ok(build_output) => build_outputs.push(build_output),
+                            Err(e) => {
+                                let issue = format!("Build output {config_path:?}: {e}");
+                                warn!("{}", issue);
+                                issues.push(issue);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Also check for convenience symlinks (bazel-bin, bazel-genfiles, etc.)
+        let symlinks = ["bazel-bin", "bazel-genfiles", "bazel-testlogs"];
+        for symlink_name in &symlinks {
+            let symlink_path = workspace_root.join(symlink_name);
+            if symlink_path.exists() {
+                match Self::analyze_symlink(workspace_root, &symlink_path, symlink_name) {
+                    Ok(Some(build_output)) => build_outputs.push(build_output),
+                    Ok(None) => {} // Not an error, just no useful info
+                    Err(e) => {
+                        let issue = format!("Symlink {symlink_path:?}: {e}");
+                        warn!("{}", issue);
+                        issues.push(issue);
+                    }
+                }
+            }
+        }
+
+        // Sort by path for consistent output
+        build_outputs.sort_by(|a, b| a.path.cmp(&b.path));
+
+        Ok(build_outputs)
+    }
+
+    fn analyze_build_output(
+        workspace_root: &Path,
+        config_path: &Path,
+        config_name: &str,
+    ) -> Result<BuildOutput, BazelError> {
+        let relative_path = config_path
+            .strip_prefix(workspace_root)
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|_| config_path.to_string_lossy().to_string());
+
+        // Parse config name (e.g., "k8-fastbuild" -> cpu="k8", compilation_mode="fastbuild")
+        let (cpu, compilation_mode) = Self::parse_config_name(config_name);
+
+        // Check for compile_commands.json in bin subdirectory
+        let compile_commands = config_path.join("bin").join("compile_commands.json");
+        let has_compile_commands = compile_commands.exists();
+
+        Ok(BuildOutput {
+            path: config_path.to_path_buf(),
+            relative_path,
+            config: Some(config_name.to_string()),
+            cpu,
+            compilation_mode,
+            has_compile_commands,
+            symlink_target: None,
+        })
+    }
+
+    fn analyze_symlink(
+        workspace_root: &Path,
+        symlink_path: &Path,
+        symlink_name: &str,
+    ) -> Result<Option<BuildOutput>, BazelError> {
+        let relative_path = symlink_path
+            .strip_prefix(workspace_root)
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|_| symlink_path.to_string_lossy().to_string());
+
+        // Try to resolve the symlink target
+        let symlink_target = symlink_path.read_link().ok();
+
+        // Check for compile_commands.json
+        let compile_commands = symlink_path.join("compile_commands.json");
+        let has_compile_commands = compile_commands.exists();
+
+        Ok(Some(BuildOutput {
+            path: symlink_path.to_path_buf(),
+            relative_path,
+            config: None,
+            cpu: None,
+            compilation_mode: None,
+            has_compile_commands,
+            symlink_target,
+        }))
+    }
+
+    fn parse_config_name(config_name: &str) -> (Option<String>, Option<String>) {
+        // Parse config names like "k8-fastbuild", "host", "k8-opt", "darwin-dbg", etc.
+        if config_name == "host" {
+            return (Some("host".to_string()), None);
+        }
+
+        if let Some(dash_pos) = config_name.rfind('-') {
+            let cpu = &config_name[..dash_pos];
+            let compilation_mode = &config_name[dash_pos + 1..];
+            (Some(cpu.to_string()), Some(compilation_mode.to_string()))
+        } else {
+            (Some(config_name.to_string()), None)
+        }
+    }
+
+    fn parse_workspace_file(workspace_file: &Path) -> Result<WorkspaceParseResult, std::io::Error> {
+        let content = fs::read_to_string(workspace_file)?;
+
+        let mut workspace_name = None;
+        let mut rules = Vec::new();
+        let mut dependencies = Vec::new();
+
+        // Parse workspace file line by line
+        for line in content.lines() {
+            let line = line.trim();
+            
+            // Skip comments and empty lines
+            if line.starts_with('#') || line.is_empty() {
+                continue;
+            }
+
+            // Extract workspace name
+            if line.starts_with("workspace(") && workspace_name.is_none() {
+                if let Some(name_start) = line.find("name = \"") {
+                    let name_start = name_start + 8; // length of "name = \""
+                    if let Some(name_end) = line[name_start..].find('"') {
+                        workspace_name = Some(line[name_start..name_start + name_end].to_string());
+                    }
+                }
+            }
+
+            // Track rule loads
+            if line.starts_with("load(") {
+                rules.push(line.to_string());
+            }
+
+            // Track repository rules (dependencies)
+            if line.contains("_repository(") || line.contains("_archive(") || line.contains("git_repository(") {
+                dependencies.push(line.to_string());
+            }
+        }
+
+        // Sort for consistent output
+        rules.sort();
+        dependencies.sort();
+
+        Ok((workspace_name, rules, dependencies, Some(workspace_file.parent().unwrap_or(workspace_file).to_path_buf())))
+    }
+
+    /// Find compilation database in Bazel build outputs
+    ///
+    /// This function looks for compile_commands.json in various Bazel output locations
+    /// and returns the path to the most suitable one.
+    #[allow(dead_code)]
+    pub fn find_compilation_database(workspace_root: &Path) -> Option<PathBuf> {
+        // Common locations for Bazel compilation databases
+        let candidates = [
+            "bazel-out/host/bin/compile_commands.json",
+            "bazel-out/k8-fastbuild/bin/compile_commands.json", 
+            "bazel-out/k8-opt/bin/compile_commands.json",
+            "bazel-out/k8-dbg/bin/compile_commands.json",
+            "bazel-bin/compile_commands.json",
+            "compile_commands.json", // Sometimes generated at root
+        ];
+
+        for candidate in &candidates {
+            let compile_commands = workspace_root.join(candidate);
+            if compile_commands.exists() {
+                return Some(compile_commands);
+            }
+        }
+
+        // Try to find any compile_commands.json in bazel-out directory
+        let bazel_out = workspace_root.join("bazel-out");
+        if bazel_out.exists() {
+            if let Ok(entries) = fs::read_dir(&bazel_out) {
+                for entry in entries.flatten() {
+                    if entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+                        let compile_commands = entry.path().join("bin/compile_commands.json");
+                        if compile_commands.exists() {
+                            return Some(compile_commands);
+                        }
+                    }
+                }
+            }
+        }
+
+        None
+    }
+}

--- a/src/legacy_lsp/client.rs
+++ b/src/legacy_lsp/client.rs
@@ -151,6 +151,8 @@ impl LspClient {
                 "--compile-commands-dir={}",
                 build_directory.display()
             ))
+            .arg("--remote-index-address=localhost:50051")
+            .arg(format!("--project-root={}", project_root.display()))
             .current_dir(project_root)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -741,7 +743,7 @@ impl LspClient {
                         if let (Some(uri), Some(state)) = (params.get("uri"), params.get("state")) {
                             if let (Some(uri_str), Some(state_str)) = (uri.as_str(), state.as_str())
                             {
-                                let file_path = uri_str.replace("file://", "");
+                                let file_path = uri_str.replace("file:///", "");
                                 let filename = std::path::Path::new(&file_path)
                                     .file_name()
                                     .and_then(|n| n.to_str())
@@ -760,7 +762,7 @@ impl LspClient {
                             if let (Some(uri_str), Some(diagnostics_array)) =
                                 (uri.as_str(), diagnostics.as_array())
                             {
-                                let file_path = uri_str.replace("file://", "");
+                                let file_path = uri_str.replace("file:///", "");
                                 let filename = std::path::Path::new(&file_path)
                                     .file_name()
                                     .and_then(|n| n.to_str())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod bazel;
 mod clangd;
 mod cmake;
 mod legacy_lsp;

--- a/src/project/bazel_provider.rs
+++ b/src/project/bazel_provider.rs
@@ -1,0 +1,175 @@
+use crate::project::{ProjectComponent, ProjectComponentProvider, ProjectError};
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Bazel project component provider
+///
+/// This provider detects Bazel workspaces by looking for WORKSPACE files
+/// and attempts to find compilation databases in bazel-out directories.
+#[allow(dead_code)]
+pub struct BazelProvider;
+
+#[allow(dead_code)]
+impl BazelProvider {
+    /// Create a new Bazel provider
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Parse WORKSPACE file and extract relevant information
+    fn parse_workspace_file(&self, workspace_file: &Path) -> Result<BazelProjectInfo, ProjectError> {
+        let content = fs::read_to_string(workspace_file).map_err(ProjectError::Io)?;
+
+        let mut workspace_name = None;
+        let mut rules = Vec::new();
+        let mut dependencies = Vec::new();
+
+        // Parse workspace file line by line
+        for line in content.lines() {
+            let line = line.trim();
+            
+            // Skip comments and empty lines
+            if line.starts_with('#') || line.is_empty() {
+                continue;
+            }
+
+            // Extract workspace name
+            if line.starts_with("workspace(") && workspace_name.is_none() {
+                if let Some(name_start) = line.find("name = \"") {
+                    let name_start = name_start + 8; // length of "name = \""
+                    if let Some(name_end) = line[name_start..].find('"') {
+                        workspace_name = Some(line[name_start..name_start + name_end].to_string());
+                    }
+                }
+            }
+
+            // Track rule loads and dependencies
+            if line.starts_with("load(") {
+                rules.push(line.to_string());
+            } else if line.contains("_repository(") {
+                dependencies.push(line.to_string());
+            }
+        }
+
+        Ok(BazelProjectInfo {
+            workspace_name,
+            rules,
+            dependencies,
+        })
+    }
+
+    /// Find compilation database in Bazel output directories
+    fn find_compilation_database(&self, workspace_root: &Path) -> Option<PathBuf> {
+        // Common locations for Bazel compilation databases
+        let candidates = [
+            "bazel-out/host/bin/compile_commands.json",
+            "bazel-out/k8-fastbuild/bin/compile_commands.json", 
+            "bazel-out/k8-opt/bin/compile_commands.json",
+            "bazel-out/k8-dbg/bin/compile_commands.json",
+            "compile_commands.json", // Sometimes generated at root
+        ];
+
+        for candidate in &candidates {
+            let compile_commands = workspace_root.join(candidate);
+            if compile_commands.exists() {
+                return Some(compile_commands);
+            }
+        }
+
+        // Try to find any compile_commands.json in bazel-out directory
+        let bazel_out = workspace_root.join("bazel-out");
+        if bazel_out.exists() {
+            if let Ok(entries) = fs::read_dir(&bazel_out) {
+                for entry in entries.flatten() {
+                    if entry.file_type().map(|ft| ft.is_dir()).unwrap_or(false) {
+                        let compile_commands = entry.path().join("bin/compile_commands.json");
+                        if compile_commands.exists() {
+                            return Some(compile_commands);
+                        }
+                    }
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Check if a directory is a Bazel workspace root
+    fn is_bazel_workspace(&self, path: &Path) -> bool {
+        path.join("WORKSPACE").exists() || path.join("WORKSPACE.bazel").exists()
+    }
+}
+
+#[allow(dead_code)]
+impl ProjectComponentProvider for BazelProvider {
+    fn name(&self) -> &str {
+        "bazel"
+    }
+
+    fn scan_path(&self, path: &Path) -> Result<Option<ProjectComponent>, ProjectError> {
+        // Check if this looks like a Bazel workspace
+        if !self.is_bazel_workspace(path) {
+            return Ok(None);
+        }
+
+        // Determine which WORKSPACE file exists
+        let workspace_file = if path.join("WORKSPACE").exists() {
+            path.join("WORKSPACE")
+        } else {
+            path.join("WORKSPACE.bazel")
+        };
+
+        // Parse the WORKSPACE file
+        let bazel_info = self.parse_workspace_file(&workspace_file)?;
+
+        // For Bazel, the workspace root is both the source root and build root
+        let source_root = path.to_path_buf();
+
+        // Try to find compilation database
+        let compilation_database_path = self.find_compilation_database(path);
+
+        // If no compilation database found, we can still create a component
+        // but it will have limited functionality
+        let compilation_database_path = compilation_database_path.unwrap_or_else(|| {
+            // Default location where Bazel might put it
+            path.join("compile_commands.json")
+        });
+
+        // Create build options from Bazel info
+        let mut build_options = HashMap::new();
+        if let Some(ref workspace_name) = bazel_info.workspace_name {
+            build_options.insert("WORKSPACE_NAME".to_string(), workspace_name.clone());
+        }
+        build_options.insert("RULES_COUNT".to_string(), bazel_info.rules.len().to_string());
+        build_options.insert("DEPS_COUNT".to_string(), bazel_info.dependencies.len().to_string());
+
+        // Create project component
+        let component = ProjectComponent::new(
+            path.to_path_buf(), // build_root = workspace_root for Bazel
+            source_root,
+            compilation_database_path,
+            "bazel".to_string(),
+            "Bazel".to_string(), // generator
+            "fastbuild".to_string(), // default build type
+            build_options,
+        )?;
+
+        Ok(Some(component))
+    }
+}
+
+impl Default for BazelProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Internal struct to hold parsed Bazel workspace information
+#[derive(Debug)]
+#[allow(dead_code)]
+struct BazelProjectInfo {
+    workspace_name: Option<String>,
+    rules: Vec<String>,
+    dependencies: Vec<String>,
+}

--- a/src/project/mod.rs
+++ b/src/project/mod.rs
@@ -4,6 +4,7 @@
 //! through a provider pattern. Each provider can detect and parse project components
 //! for their respective build system.
 
+pub mod bazel_provider;
 pub mod cmake_provider;
 pub mod compilation_database;
 pub mod component;
@@ -13,6 +14,8 @@ pub mod meta_project;
 pub mod provider;
 pub mod scanner;
 
+#[allow(unused_imports)]
+pub use bazel_provider::BazelProvider;
 #[allow(unused_imports)]
 pub use cmake_provider::CmakeProvider;
 #[allow(unused_imports)]


### PR DESCRIPTION
I'm just sharing this draft PR in order to show the hacks that worked to get mcp-cpp mostly working with bazel and windows and using clangd remote indexes. For our large codebase clangd remote is ideal as we can index offline and share the index between machines.

Workflow is:
Central server overnight job:
clangd-indexer (to build index)
clangd-index-server (to serve index)

Dev machines:
mcp-cpp with clangd --remote-index option

I've also added:
- some AI slop bazel workspace detection
- windows URI parsing hacks (file:///C:/path/to/file needs to map to C:\path\to\file)
- canonicalize filenames in order to better match project root

I'm hoping you will take & refine some of these inputs as you are refactoring?