### PR TITLE
chore: Add a pre-commit hook definition

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all --
+        language: system
+        types: [rust]
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --all-targets --all-features -- -D warnings
+        language: system
+        types: [rust]
+        pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -382,6 +382,15 @@ analyze_symbol_context {"symbol": "MyClass"}
 analyze_symbol_context {"symbol": "MyClass::process", "max_examples": 3}
 ```
 
+## Developing
+
+Install [pre-commit](https://pre-commit.com/) to run formatting and linting checks before each commit:
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
 ## Limitations
 
 - Requires CMake or Meson projects that generate `compile_commands.json`


### PR DESCRIPTION
This includes formatting and linting (clippy), this will ensure that PRs do not break the GH workflow due to formatting and linting.

Solves issue #15 